### PR TITLE
2 auto sleepmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ The Makefile provides a set of commands to build, flash, and monitor the microco
 ## Usage
 When you use the ESP32 in Access Point mode, the ESP32 creates its own WiFi network. The default IP address to access the ESP32's web server is: http://192.168.4.1 You can open your web browser and enter this IP address to access the web services and features provided by the ESP32.
 
+### Pinout
+The following table shows the pinout of the ESP32 microcontroller. The pinout of the DS3231 RTC module and the motor control module may vary depending on the manufacturer.
+| ESP32 Pin | RTC Pin |
+| --------- | ------- |
+| 21        | SDA     |
+| 22        | SCL     |
+| 4         | INT     |
+| 3.3V      | VCC     |
+| GND       | GND     |
+
+| ESP32 Pin | Motor Pin |
+| --------- | --------- |
+| 2         | OUT       |
+| GND       | GND       |
+| 3.3V      | VCC       |
 
 ## Contributions and Collaboration
 We welcome contributions and collaboration on this project. If you would like to make improvements, fix bugs, or add new features, please create an issue or a pull request.

--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ We welcome contributions and collaboration on this project. If you would like to
 
 ## Author
 - [Friedjof Noweck](https://github.com/Friedjof)
+- [Bernhard schlagheck](https://github.com/bschlagheck)

--- a/data/config.json-template
+++ b/data/config.json-template
@@ -3,6 +3,10 @@
         "ssid": "Chicken feeder",
         "password": "password"
     },
+    "system": {
+        "auto_sleep": true,
+        "auto_sleep_after": 300
+    },
     "feed": {
         "quantity": 100
     },

--- a/lib/ConfigManager/ConfigManager.cpp
+++ b/lib/ConfigManager/ConfigManager.cpp
@@ -68,6 +68,10 @@ void ConfigManager::load_config() {
     // Copy values from the JsonDocument to the Config
     strlcpy(this->config.wifi.ssid, doc["wifi"]["ssid"] | "", sizeof(this->config.wifi.ssid));
     strlcpy(this->config.wifi.password, doc["wifi"]["password"] | "", sizeof(this->config.wifi.password));
+    
+    // Copy system config
+    this->config.system.auto_sleep = doc["system"]["auto_sleep"] | false;
+    this->config.system.auto_sleep_after = doc["system"]["auto_sleep_after"] | 300;
 
     // Feed
     this->config.feed.quantity = doc["feed"]["quantity"] | 0;
@@ -121,6 +125,10 @@ void ConfigManager::save_config() {
     // Set the values in the document
     doc["wifi"]["ssid"] = this->config.wifi.ssid;
     doc["wifi"]["password"] = this->config.wifi.password;
+
+    // Set system config
+    doc["system"]["auto_sleep"] = this->config.system.auto_sleep;
+    doc["system"]["auto_sleep_after"] = this->config.system.auto_sleep_after;
 
     // feed
     doc["feed"]["quantity"] = this->config.feed.quantity;
@@ -364,6 +372,10 @@ timer_config_list_t ConfigManager::sort_timers_by_time(timer_config_list_t timer
 
 feed_config_t ConfigManager::get_feed_config() {
     return this->config.feed;
+}
+
+system_t ConfigManager::get_system_config() {
+    return this->config.system;
 }
 
 // debugging functions

--- a/lib/ConfigManager/ConfigManager.h
+++ b/lib/ConfigManager/ConfigManager.h
@@ -28,6 +28,11 @@ typedef struct {
 } timer_time_t;
 
 typedef struct {
+    bool auto_sleep;
+    int auto_sleep_after;
+} system_t;
+
+typedef struct {
     char ssid[MAX_WIFI_SSID_LENGTH];
     char password[MAX_WIFI_PASSWORD_LENGTH];
 } local_wifi_config_t;
@@ -64,6 +69,7 @@ typedef struct {
     local_wifi_config_t wifi;
     timer_config_list_t timer_list;
     feed_config_t feed;
+    system_t system;
 } config_t;
 
 
@@ -93,6 +99,7 @@ class ConfigManager {
         timer_config_list_t get_timers();
         StaticJsonDocument<JSON_BUFFER_SIZE> get_timers_json();
         feed_config_t get_feed_config();
+        system_t get_system_config();
 
         void set_timers_json(JsonVariant &json);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,8 +32,8 @@
 #define CSS_FILE "/style.css"
 #define JS_FILE "/script.js"
 
-#define RELAY_PIN 2 // D2 (Onboard LED)
-#define CLINT 4     // RTC interrupt pin for alarm 1
+#define RELAY_PIN 2  // D2 (Onboard LED)
+#define CLINT 4      // RTC interrupt pin for alarm 1
 
 // Prototypes
 void IRAM_ATTR interrupt_handler();
@@ -41,10 +41,12 @@ void setup_wifi();  // Setup WiFi
 void setup_aws();   // Setup AsyncWebServer
 
 void feed();        // Feed the chickens
+void new_request(); // Will be executed when a new request is received
 
 // Global variables
 bool interrupt_flag = false;
 unsigned long feed_millis = millis();
+unsigned long auto_sleep_millis = millis();
 
 // deep sleep
 #ifdef ESP32DEV
@@ -114,15 +116,28 @@ void setup() {
 }
 
 void loop() {
+  // handle interrupt
   if (interrupt_flag) {
     feed();
   }
+
+  // auto sleep depending on AUTO_SLEEP
+  if (configManager.get_system_config().auto_sleep && (millis() - auto_sleep_millis > 1000 * configManager.get_system_config().auto_sleep_after)) {
+    Serial.println("Going to sleep because of auto sleep");
+    #ifdef ESP32DEV
+    esp_deep_sleep_start();
+    #else
+    ESP.deepSleep(0);
+    #endif
+  }
 }
 
+// Interrupt handler
 void IRAM_ATTR interrupt_handler() {
   interrupt_flag = true;
 }
 
+// Feed the chickens
 void feed() {
   Serial.println("Fütterung gestartet");
   digitalWrite(RELAY_PIN, HIGH);
@@ -133,6 +148,12 @@ void feed() {
 
   // Setup the new alert (if necessary)
   alertManager.set_next_alert();
+}
+
+// Will be executed when a new request is received
+void new_request() {
+  // reset auto sleep millis to prevent going to sleep
+  auto_sleep_millis = millis();
 }
 
 void setup_wifi() {
@@ -156,6 +177,8 @@ void setup_wifi() {
 
 void setup_aws() {
   server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
+    new_request();
+
     #ifdef ESP32DEV
     request->send(SPIFFS, INDEX_FILE, "text/html");
     #else
@@ -180,6 +203,8 @@ void setup_aws() {
   });
 
   server.on("/get", HTTP_GET, [](AsyncWebServerRequest *request) {
+    new_request();
+
     String jsonString;
     serializeJson(configManager.get_timers_json(), jsonString);
 
@@ -190,6 +215,8 @@ void setup_aws() {
 
   // This endpoint is used to set the timers
   AsyncCallbackJsonWebHandler* set_handler = new AsyncCallbackJsonWebHandler("/set", [](AsyncWebServerRequest *request, JsonVariant &json) {
+    new_request();
+
     // Convert the data to a JSON object
     Serial.println("Set new configuration");
     configManager.set_timers_json(json);
@@ -204,6 +231,8 @@ void setup_aws() {
 
   // activate sleep mode
   server.on("/sleep", HTTP_GET, [](AsyncWebServerRequest *request) {
+    new_request();
+
     Serial.println("Schlafmodus aktiviert");
     
     // go to sleep
@@ -217,6 +246,8 @@ void setup_aws() {
 
   // get current time
   server.on("/time", HTTP_GET, [](AsyncWebServerRequest *request) {
+    new_request();
+
     // get current time
     ds3231_datetime_t now = alertManager.now();
 
@@ -229,19 +260,6 @@ void setup_aws() {
     json["minute"] = now.minute;
     json["second"] = now.second;
 
-    Serial.print("Get current time: ");
-    Serial.print(now.year);
-    Serial.print("-");
-    Serial.print(now.month);
-    Serial.print("-");
-    Serial.print(now.day);
-    Serial.print(" ");
-    Serial.print(now.hour);
-    Serial.print(":");
-    Serial.print(now.minute);
-    Serial.print(":");
-    Serial.println(now.second);
-
     String jsonString;
     serializeJson(json, jsonString);
 
@@ -250,6 +268,8 @@ void setup_aws() {
 
   // feed manually
   AsyncCallbackJsonWebHandler* feed_handler = new AsyncCallbackJsonWebHandler("/feed", [](AsyncWebServerRequest *request, JsonVariant &json) {
+    new_request();
+
     // if 'on' is true, start feeding
     if (json.containsKey("on") && json["on"].is<bool>()) {
       if (json["on"].as<bool>()) {


### PR DESCRIPTION
## Quick guide
- can be configured in the config.json
- two parameters:
  - `auto_sleep`: true or false
  - `auto_sleep_after`: if `auto_sleep` is `true` this is the time in sec after inactivity
## More details
Inactivity is reached when no requests have been made via the API for longer than the set time. This also includes the automatic query of the time. In summary, the sleep mode is only activated if the website for the configuration is no longer actively visited and the set time has elapsed.