### PR TITLE
13 change spiffs to littlefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ esptool.py --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard
 ```
 Change the `--port` parameter to match your system configuration and the path to the binary files.
 
-#### spiffs.bin
+#### littlefs.bin (ESP32 and ESP8266)
 ```bash
-esptool.py --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x290000 spiffs.bin
+esptool.py --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x290000 littlefs.bin
 ```
 Change the `--port` parameter to match your system configuration and the path to the binary files.
 

--- a/lib/ConfigManager/ConfigManager.cpp
+++ b/lib/ConfigManager/ConfigManager.cpp
@@ -4,13 +4,11 @@
 ConfigManager::ConfigManager(const char* filename) {
     this->filename = filename;
 
-    #ifdef ESP32DEV
-    // start SPIFFS
-    if (!SPIFFS.begin(true)) {
-        Serial.println("Could not initialize SPIFFS");
+    // start LittleFS
+    if (!LittleFS.begin()) {
+        Serial.println("Could not initialize LittleFS");
         return;
     }
-    #endif
     
     // load config
     this->load_config();
@@ -18,18 +16,12 @@ ConfigManager::ConfigManager(const char* filename) {
 
 ConfigManager::ConfigManager() {
     this->filename = DEFAULT_CONFIG_FILE;
-    // start SPIFFS
-    #ifdef ESP32DEV
-    if (!SPIFFS.begin(true)) {
-        Serial.println("Could not initialize SPIFFS");
-        return;
-    }
-    #else
+
+    // start LittleFS
     if (!LittleFS.begin()) {
         Serial.println("Could not initialize LittleFS");
         return;
     }
-    #endif
 
     // load config
     this->load_config();
@@ -37,17 +29,13 @@ ConfigManager::ConfigManager() {
 
 ConfigManager::~ConfigManager() { }
 
-// load config from SPIFFS
+// load config from LittleFS
 void ConfigManager::load_config() {
     Serial.println("Loading config");
     Serial.print("Filename: ");
     Serial.println(this->filename);
     // Open file for reading
-    #ifdef ESP32DEV
-    File file = SPIFFS.open(this->filename, FILE_READ);
-    #else
     File file = LittleFS.open(this->filename, "r");
-    #endif
 
     if (!file) {
         Serial.println("Failed to open config file");
@@ -106,14 +94,10 @@ void ConfigManager::load_config() {
     file.close();
 }
 
-// save config to SPIFFS
+// save config to LittleFS
 void ConfigManager::save_config() {
     // open file for writing
-    #ifdef ESP32DEV
-    File file = SPIFFS.open(this->filename, FILE_WRITE);
-    #else
     File file = LittleFS.open(this->filename, "w");
-    #endif
 
     if (!file) {
         Serial.println("Failed to create file");

--- a/lib/ConfigManager/ConfigManager.h
+++ b/lib/ConfigManager/ConfigManager.h
@@ -13,11 +13,7 @@
 
 #include <Arduino.h>
 
-#ifdef ESP32DEV
-#include <SPIFFS.h>
-#else
 #include <LittleFS.h>
-#endif
 
 #include <ArduinoJson.h>
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,6 +32,7 @@ monitor_speed = 9600
 monitor_port = /dev/ttyUSB0
 upload_speed = 921600
 build_flags = -D ESP32DEV
+board_build.filesystem = littlefs
 lib_deps =
     Wifi
     https://github.com/bblanchon/ArduinoJson.git

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,14 +4,13 @@
 
 #include <AsyncJson.h>
 #include <ArduinoJson.h>
+#include <LittleFS.h>
 
 #ifdef ESP32DEV
 #include <WiFi.h>
-#include <SPIFFS.h>
 #else
 #include <ESPAsyncTCP.h>
 #include <ESP8266WiFi.h>
-#include <LittleFS.h>
 #endif
 
 #include <SPI.h>
@@ -126,7 +125,7 @@ void loop() {
   }
 
   // auto sleep depending on AUTO_SLEEP
-  if (configManager.get_system_config().auto_sleep && (millis() - auto_sleep_millis > 1000 * configManager.get_system_config().auto_sleep_after)) {
+  if (configManager.get_system_config().auto_sleep && (millis() - auto_sleep_millis > (long unsigned int)(1000 * configManager.get_system_config().auto_sleep_after))) {
     Serial.println("Going to sleep because of auto sleep");
     #ifdef ESP32DEV
     esp_deep_sleep_start();
@@ -172,7 +171,7 @@ void setup_wifi() {
 
   Serial.println("Starte WiFi Access Point");
   WiFi.softAP(configManager.get_wifi_ssid(), configManager.get_wifi_password());
-  
+
   Serial.println();
   Serial.print("Hotspot-SSID: ");
   Serial.println(configManager.get_wifi_ssid());
@@ -185,27 +184,15 @@ void setup_aws() {
   server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
     new_request();
 
-    #ifdef ESP32DEV
-    request->send(SPIFFS, INDEX_FILE, "text/html");
-    #else
     request->send(LittleFS, INDEX_FILE, "text/html");
-    #endif
   });
   
   server.on("/style.css", HTTP_GET, [](AsyncWebServerRequest *request) {
-    #ifdef ESP32DEV
-    request->send(SPIFFS, CSS_FILE, "text/css");
-    #else
     request->send(LittleFS, CSS_FILE, "text/css");
-    #endif
   });
 
   server.on("/script.js", HTTP_GET, [](AsyncWebServerRequest *request) {
-    #ifdef ESP32DEV
-    request->send(SPIFFS, JS_FILE, "text/javascript");
-    #else
     request->send(LittleFS, JS_FILE, "text/javascript");
-    #endif
   });
 
   server.on("/get", HTTP_GET, [](AsyncWebServerRequest *request) {


### PR DESCRIPTION
The change has worked well. The number of case distinctions between the esp32 and the esp8266 has now become somewhat smaller. However, ESPAsyncWebServer grumbles a bit when using LittleFS. But actually this should be completely the same from the API and it doesn't lead to such an error.
The binary file for the file system has of course also changed and therefore the README.md had to be adapted in one place. Otherwise, everything should now work the same as with spiffs.